### PR TITLE
Add step package processing and simulation utilities

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,3 +3,5 @@
 export(check_ce_data)
 export(launch_ce_app)
 export(plot_ce_sankey)
+export(simulate_step_data)
+export(summarise_step_packages)

--- a/R/simulate_steps.R
+++ b/R/simulate_steps.R
@@ -1,0 +1,67 @@
+#' Simulate prioritisation step data
+#'
+#' Generate example step and package data for testing Sankey diagrams.
+#'
+#' @param n Number of simulations per grouping combination.
+#' @param all_interventions All possible interventions.
+#' @param removable Interventions that can be added or removed.
+#' @param pfpr Levels of PfPr grouping variable.
+#' @param seasonality Levels of seasonality grouping variable.
+#'
+#' @return A data frame with columns for grouping variables, simulation id,
+#'   step number, and package label.
+#' @export
+simulate_step_data <- function(n = 10,
+                               all_interventions = c("ITN", "Chemoprevention", "Vaccine", "CM"),
+                               removable = c("ITN", "Chemoprevention", "Vaccine"),
+                               pfpr = c("low", "high"),
+                               seasonality = c("low", "high")) {
+  groups <- tidyr::crossing(pfpr = pfpr, seasonality = seasonality)
+  res_list <- list()
+  counter <- 1
+
+  for (g in seq_len(nrow(groups))) {
+    grp_vals <- groups[g, , drop = FALSE]
+    for (id in seq_len(n)) {
+      base_n <- sample(length(all_interventions), 1)
+      current <- sort(sample(all_interventions, base_n))
+      steps <- list(data.frame(step = 0L,
+                               package = paste(current, collapse = " & "),
+                               stringsAsFactors = FALSE))
+
+      current_neg <- current
+      for (s in seq_along(removable)) {
+        removable_now <- intersect(current_neg, removable)
+        if (length(removable_now) == 0) break
+        rem <- sample(removable_now, 1)
+        current_neg <- setdiff(current_neg, rem)
+        pkg <- if (length(current_neg) > 0) paste(sort(current_neg), collapse = " & ") else "None"
+        steps[[length(steps) + 1]] <- data.frame(step = -s,
+                                                 package = pkg,
+                                                 stringsAsFactors = FALSE)
+      }
+
+      current_pos <- current
+      to_add <- setdiff(removable, current_pos)
+      if (length(to_add) > 0) {
+        add_order <- sample(to_add)
+        for (s in seq_along(add_order)) {
+          current_pos <- sort(c(current_pos, add_order[s]))
+          pkg <- paste(current_pos, collapse = " & ")
+          steps[[length(steps) + 1]] <- data.frame(step = s,
+                                                   package = pkg,
+                                                   stringsAsFactors = FALSE)
+        }
+      }
+
+      step_df <- dplyr::bind_rows(steps)
+      step_df$step <- as.integer(step_df$step)
+      step_df$id <- id
+      step_df <- cbind(step_df, grp_vals)
+      res_list[[counter]] <- step_df
+      counter <- counter + 1
+    }
+  }
+
+  dplyr::bind_rows(res_list)
+}

--- a/R/step_packages.R
+++ b/R/step_packages.R
@@ -1,0 +1,32 @@
+#' Summarise intervention packages by step
+#'
+#' Calculate the proportion of each intervention package within a step
+#' for specified grouping variables.
+#'
+#' @param df Data frame containing prioritisation steps.
+#' @param step_col Name of the step column.
+#' @param package_col Name of the package column.
+#' @param group_cols Character vector of grouping column names.
+#'
+#' @return A data frame with counts and proportions of packages at each step.
+#' @export
+summarise_step_packages <- function(df,
+                                    step_col = "step",
+                                    package_col = "package",
+                                    group_cols = character()) {
+  if (!is.data.frame(df)) {
+    stop("`df` must be a data frame.", call. = FALSE)
+  }
+
+  cols_needed <- c(step_col, package_col, group_cols)
+  missing_cols <- setdiff(cols_needed, names(df))
+  if (length(missing_cols) > 0) {
+    stop("Missing columns: ", paste(missing_cols, collapse = ", "), call. = FALSE)
+  }
+
+  dplyr::group_by(df, dplyr::across(dplyr::all_of(c(group_cols, step_col, package_col)))) %>%
+    dplyr::summarise(n = dplyr::n(), .groups = "drop") %>%
+    dplyr::group_by(dplyr::across(dplyr::all_of(c(group_cols, step_col)))) %>%
+    dplyr::mutate(prop = n / sum(n)) %>%
+    dplyr::ungroup()
+}

--- a/tests/testthat/test-step_packages.R
+++ b/tests/testthat/test-step_packages.R
@@ -1,0 +1,23 @@
+test_that("summarise_step_packages computes proportions", {
+  df <- data.frame(
+    step = c(0, 0, 0, -1, -1),
+    package = c("A", "A", "B", "A", "B"),
+    grp = "G",
+    stringsAsFactors = FALSE
+  )
+  res <- summarise_step_packages(df, group_cols = "grp")
+  expect_equal(res$prop[res$step == 0 & res$package == "A"], 2 / 3)
+  expect_equal(res$prop[res$step == 0 & res$package == "B"], 1 / 3)
+  sums <- res |> dplyr::group_by(grp, step) |> dplyr::summarise(t = sum(prop), .groups = "drop")
+  expect_true(all(abs(sums$t - 1) < 1e-8))
+})
+
+test_that("simulate_step_data generates expected structure", {
+  set.seed(1)
+  df <- simulate_step_data(n = 2)
+  expect_true(all(c("pfpr", "seasonality", "id", "step", "package") %in% names(df)))
+  expect_s3_class(df, "data.frame")
+  expect_true(is.integer(df$step))
+  chk <- df |> dplyr::group_by(pfpr, seasonality, id) |> dplyr::summarise(has0 = any(step == 0), .groups = "drop")
+  expect_true(all(chk$has0))
+})


### PR DESCRIPTION
## Summary
- add `summarise_step_packages` to compute package proportions per step
- add `simulate_step_data` to generate sample intervention sequences
- export new utilities and provide tests

## Testing
- `R -q -e 'devtools::document()'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e099ae8c8326b08c3327ea931e0b