### PR TITLE
Refactor step Sankey plotting for staged packages

### DIFF
--- a/R/sankey_static.R
+++ b/R/sankey_static.R
@@ -1,13 +1,14 @@
 #' Plot a step-package Sankey diagram
 #'
-#' Build a Sankey diagram from summarised step package data using either
-#' `networkD3` or `ggsankey`.
+#' Build a Sankey diagram showing how intervention packages change across
+#' sequential steps. Each step forms a stage in the diagram and packages are
+#' displayed as nodes within those stages.
 #'
-#' @param df Data frame containing step package summaries.
+#' @param df Data frame containing step package data.
 #' @param step_col Name of the step column.
 #' @param package_col Name of the package column.
-#' @param n_col Name of the count column.
-#' @param group_cols Ordered character vector of additional grouping columns.
+#' @param group_cols Character vector of grouping columns excluding `id_col`.
+#' @param id_col Name of the identifier column defining unique sequences.
 #' @param engine Rendering engine: either "networkD3" or "ggsankey".
 #'
 #' @return An `htmlwidget` (networkD3) or `ggplot` (ggsankey) object.
@@ -15,30 +16,52 @@
 plot_step_sankey <- function(df,
                              step_col = "step",
                              package_col = "package",
-                             n_col = "n",
                              group_cols = character(),
+                             id_col = "id",
                              engine = c("networkD3", "ggsankey")) {
   engine <- match.arg(engine)
-  check_step_data(df, step_col, package_col, n_col, "prop", group_cols)
 
-  all_cols <- c(group_cols, step_col, package_col)
-  if (length(all_cols) < 2) {
-    stop("`group_cols` must define a sequence including step and package.", call. = FALSE)
+  required <- c(step_col, package_col, group_cols, id_col)
+  missing_cols <- setdiff(required, names(df))
+  if (length(missing_cols) > 0) {
+    stop("Missing columns: ", paste(missing_cols, collapse = ", "), call. = FALSE)
   }
 
+  step_vals <- sort(unique(df[[step_col]]))
+  if (length(step_vals) < 2) {
+    stop("Need at least two distinct steps to build a Sankey diagram.", call. = FALSE)
+  }
+
+  step_syms <- rlang::syms(as.character(step_vals))
+
+  seq_df <- dplyr::select(df, dplyr::all_of(c(group_cols, id_col, step_col, package_col)))
+  wide_df <- tidyr::pivot_wider(
+    seq_df,
+    names_from = !!rlang::sym(step_col),
+    values_from = !!rlang::sym(package_col)
+  )
+
+  path_df <- dplyr::count(
+    wide_df,
+    dplyr::across(dplyr::all_of(c(group_cols, as.character(step_vals)))),
+    name = "value"
+  )
+
   if (engine == "networkD3") {
-    links_list <- lapply(seq_len(length(all_cols) - 1), function(i) {
-      dplyr::group_by(df, .data[[all_cols[i]]], .data[[all_cols[i + 1]]]) %>%
-        dplyr::summarise(value = sum(.data[[n_col]]), .groups = "drop") %>%
+    links_list <- lapply(seq_len(length(step_vals) - 1), function(i) {
+      dplyr::group_by(path_df, .data[[as.character(step_vals[i])]], .data[[as.character(step_vals[i + 1])]]) %>%
+        dplyr::summarise(value = sum(.data$value), .groups = "drop") %>%
         dplyr::mutate(
-          source = paste(all_cols[i], .data[[all_cols[i]]], sep = ": "),
-          target = paste(all_cols[i + 1], .data[[all_cols[i + 1]]], sep = ": ")
+          source = paste(step_vals[i], .data[[as.character(step_vals[i])]], sep = "|"),
+          target = paste(step_vals[i + 1], .data[[as.character(step_vals[i + 1])]], sep = "|")
         ) %>%
         dplyr::select(source, target, value)
     })
 
     links <- dplyr::bind_rows(links_list)
     nodes <- data.frame(name = unique(c(links$source, links$target)), stringsAsFactors = FALSE)
+    nodes$label <- sub("^[^|]+\|", "", nodes$name)
+    nodes$group <- sub("\|.*$", "", nodes$name)
     links$source <- match(links$source, nodes$name) - 1
     links$target <- match(links$target, nodes$name) - 1
 
@@ -48,10 +71,11 @@ plot_step_sankey <- function(df,
       Source = "source",
       Target = "target",
       Value = "value",
-      NodeID = "name"
+      NodeID = "label",
+      NodeGroup = "group"
     )
   } else {
-    long_df <- ggsankey::make_long(df, !!!rlang::syms(all_cols), value = !!rlang::sym(n_col))
+    long_df <- ggsankey::make_long(path_df, !!!step_syms, value = value)
     ggplot2::ggplot(
       long_df,
       ggplot2::aes(

--- a/tests/testthat/test-sankey_static.R
+++ b/tests/testthat/test-sankey_static.R
@@ -1,12 +1,14 @@
 test_that("plot_step_sankey returns networkD3 widget", {
-  df <- data.frame(grp = "G", step = c(-1, -1), package = c("A", "B"), n = c(1, 2), prop = c(1/3, 2/3))
-  p <- plot_step_sankey(df, group_cols = "grp", engine = "networkD3")
+  set.seed(1)
+  df <- simulate_step_data(n = 2, pfpr = "low", seasonality = "low")
+  p <- plot_step_sankey(df, group_cols = c("pfpr", "seasonality"), id_col = "id", engine = "networkD3")
   expect_s3_class(p, "htmlwidget")
 })
 
 test_that("plot_step_sankey returns ggplot", {
   skip_if_not_installed("ggsankey")
-  df <- data.frame(grp = "G", step = c(-1, -1), package = c("A", "B"), n = c(1, 2), prop = c(1/3, 2/3))
-  p <- plot_step_sankey(df, group_cols = "grp", engine = "ggsankey")
+  set.seed(1)
+  df <- simulate_step_data(n = 2, pfpr = "low", seasonality = "low")
+  p <- plot_step_sankey(df, group_cols = c("pfpr", "seasonality"), id_col = "id", engine = "ggsankey")
   expect_s3_class(p, "ggplot")
 })


### PR DESCRIPTION
## Summary
- refine plot_step_sankey to accept raw step-package data with sequence ids
- test Sankey plotting using simulate_step_data outputs

## Testing
- `Rscript -e 'devtools::document()'` *(fails: command not found: Rscript)*
- `Rscript -e 'devtools::test()'` *(fails: command not found: Rscript)*
- `Rscript -e 'devtools::check()'` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e7e7ce6c832696a04d8c85b6fe51